### PR TITLE
fix a bug about parser.add_argument

### DIFF
--- a/Extend_inD/scripts/Trans_trainer.py
+++ b/Extend_inD/scripts/Trans_trainer.py
@@ -47,7 +47,7 @@ def main():
     parser.add_argument('--beta', type=float, default=0.65, help='Loss weight')
     parser.add_argument('--query_dim', type=int, default=4, help='The dimension of the query')
     parser.add_argument('--keyvalue_dim', type=int, default=4, help='The dimension for key and value')    
-    parser.add_argument('--train_mode', type=bool, default=True, help='This is the training mode')
+    parser.add_argument('--train_mode', action='store_false', default=True, help='This is the training mode')
     parser.add_argument('--train_set', type=str, choices=['Train'], default='sharedspaces', 
                         help='This is the directories for the training data')
     parser.add_argument('--challenge_set', type=str, choices=['Test'], default='Test', 

--- a/Extend_inD/scripts/ame_trainer.py
+++ b/Extend_inD/scripts/ame_trainer.py
@@ -48,7 +48,7 @@ def main():
     parser.add_argument('--beta', type=float, default=0.65, help='Loss weight')
     parser.add_argument('--query_dim', type=int, default=2, help='The dimension of the query')
     parser.add_argument('--keyvalue_dim', type=int, default=2, help='The dimension for key and value')    
-    parser.add_argument('--train_mode', type=bool, default=True, help='This is the training mode')
+    parser.add_argument('--train_mode', action='store_false', default=True, help='This is the training mode')
     parser.add_argument('--train_set', type=str, choices=['Train'], default='sharedspaces', 
                         help='This is the directories for the training data')
     parser.add_argument('--challenge_set', type=str, choices=['Test'], default='Test', 

--- a/scripts/trainer.py
+++ b/scripts/trainer.py
@@ -47,7 +47,7 @@ def main():
     parser.add_argument('--beta', type=float, default=0.65, help='Loss weight')  # 0.75#0.65
     parser.add_argument('--query_dim', type=int, default=4, help='The dimension of the query')
     parser.add_argument('--keyvalue_dim', type=int, default=4, help='The dimension for key and value')
-    parser.add_argument('--train_mode', type=bool, default=True, help='This is the training mode')
+    parser.add_argument('--train_mode', action='store_false', default=True, help='This is the training mode')
     parser.add_argument('--train_set', type=str, choices=['Train'], default='Train',
                         help='This is the directories for the training data')
     parser.add_argument('--challenge_set', type=str, choices=['Test'], default='Test',


### PR DESCRIPTION
When bool-type variables pass to ArgumentParser, the incoming parameters are processed as strings, so no matter what value is passed, the parameter value is True. It is recommended to replace it with the parameter `action=store_true/store_false`